### PR TITLE
Added Crowdin Translation Provider

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -154,6 +154,7 @@ use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\String\LazyString;
 use Symfony\Component\String\Slugger\SluggerInterface;
+use Symfony\Component\Translation\Bridge\Crowdin\Provider\CrowdinProviderFactory;
 use Symfony\Component\Translation\Bridge\Loco\Provider\LocoProviderFactory;
 use Symfony\Component\Translation\Bridge\Lokalise\Provider\LokaliseProviderFactory;
 use Symfony\Component\Translation\Bridge\PoEditor\Provider\PoEditorProviderFactory;
@@ -1252,6 +1253,7 @@ class FrameworkExtension extends Extension
                 LocoProviderFactory::class => 'translation.provider_factory.loco',
                 PoEditorProviderFactory::class => 'translation.provider_factory.poeditor',
                 LokaliseProviderFactory::class => 'translation.provider_factory.lokalise',
+                CrowdinProviderFactory::class => 'translation.provider_factory.crowdin',
             ];
 
             foreach ($classToServices as $class => $service) {
@@ -1351,6 +1353,7 @@ class FrameworkExtension extends Extension
                 LocoProviderFactory::class => 'translation.provider_factory.loco',
                 PoEditorProviderFactory::class => 'translation.provider_factory.poeditor',
                 LokaliseProviderFactory::class => 'translation.provider_factory.lokalise',
+                CrowdinProviderFactory::class => 'translation.provider_factory.crowdin',
             ];
 
             foreach ($classToServices as $class => $service) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_providers.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_providers.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\Translation\Bridge\Crowdin\Provider\CrowdinProviderFactory;
 use Symfony\Component\Translation\Bridge\Loco\Provider\LocoProviderFactory;
 use Symfony\Component\Translation\Bridge\Lokalise\Provider\LokaliseProviderFactory;
 use Symfony\Component\Translation\Bridge\PoEditor\Provider\PoEditorProviderFactory;
@@ -33,6 +34,14 @@ return static function (ContainerConfigurator $container) {
             ])
             ->parent('translation.provider_factory.abstract')
             ->tag('translation.provider_factory')
+
+        ->set('translation.provider_factory.crowdin', CrowdinProviderFactory::class)
+        ->args([
+            service('translation.loader.xliff'),
+            service('translation.dumper.xliff'),
+        ])
+        ->parent('translation.provider_factory.abstract')
+        ->tag('translation.provider_factory')
 
         ->set('translation.provider_factory.loco', LocoProviderFactory::class)
             ->args([

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/.gitattributes
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/.gitignore
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.3.0
+-----
+
+ * Created the bridge

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/LICENSE
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020-2021 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Provider/CrowdinProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Provider/CrowdinProvider.php
@@ -1,0 +1,469 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Bridge\Crowdin\Provider;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\Dumper\XliffFileDumper;
+use Symfony\Component\Translation\Exception\ProviderException;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Provider\AbstractProvider;
+use Symfony\Component\Translation\TranslatorBag;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Andrii Bodnar <andrii.bodnar@crowdin.com>
+ *
+ * @experimental in 5.3
+ *
+ * In Crowdin:
+ * Filenames refers to Symfony's translation domains;
+ * Identifiers refers to Symfony's translation keys;
+ * Translations refers to Symfony's translated messages
+ */
+final class CrowdinProvider extends AbstractProvider
+{
+    protected const HOST = 'api.crowdin.com/api/v2';
+
+    /** @var string */
+    private $apiToken;
+
+    /** @var string */
+    private $projectId;
+
+    /** @var string */
+    private $organizationDomain;
+
+    private $xliffFileDumper;
+
+    private $files = [];
+
+    /** @var LoaderInterface|null */
+    private $loader;
+
+    /** @var LoggerInterface|null */
+    private $logger;
+
+    /** @var string|null */
+    private $defaultLocale;
+
+    public function __construct(string $projectId, string $apiToken, string $organizationDomain = null, HttpClientInterface $client = null, LoaderInterface $loader = null, LoggerInterface $logger = null, string $defaultLocale = null, XliffFileDumper $xliffFileDumper = null)
+    {
+        $this->projectId = $projectId;
+        $this->apiToken = $apiToken;
+        $this->organizationDomain = $organizationDomain;
+        $this->loader = $loader;
+        $this->logger = $logger;
+        $this->defaultLocale = $defaultLocale;
+        $this->xliffFileDumper = $xliffFileDumper;
+
+        parent::__construct($client);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf(CrowdinProviderFactory::SCHEME . '://%s', $this->getEndpoint());
+    }
+
+    public function getName(): string
+    {
+        return CrowdinProviderFactory::SCHEME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write(TranslatorBag $translatorBag): void
+    {
+        foreach($translatorBag->getDomains() as $domain) {
+            /** @var MessageCatalogue $catalogue */
+            foreach ($translatorBag->getCatalogues() as $catalogue) {
+                $content = $this->xliffFileDumper->formatCatalogue($catalogue, $domain);
+
+                $fileId = $this->getFileId($domain);
+
+                if ($catalogue->getLocale() === $this->defaultLocale) {
+                    if (!$fileId) {
+                        $this->addFile($domain, $content);
+                    } else {
+                        $this->updateFile($fileId, $domain, $content);
+                    }
+                } else {
+                    $this->uploadTranslations($fileId, $domain, $content, $catalogue->getLocale());
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read(array $domains, array $locales): TranslatorBag
+    {
+        $translatorBag = new TranslatorBag();
+
+        foreach ($domains as $domain) {
+            $fileId = $this->getFileId($domain);
+
+            if (!$fileId) {
+                continue;
+            }
+
+            foreach ($locales as $locale) {
+                if ($locale !== $this->defaultLocale) {
+                    $content = $this->exportProjectTranslations($locale, $fileId);
+                } else {
+                    $content = $this->downloadSourceFile($fileId);
+                }
+
+                $translatorBag->addCatalogue($this->loader->load($content, $locale, $domain));
+            }
+        }
+
+        return $translatorBag;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete(TranslatorBag $translatorBag): void
+    {
+        foreach ($translatorBag->all() as $locale => $domainMessages) {
+            if ($locale !== $this->defaultLocale) {
+                continue;
+            }
+
+            foreach ($domainMessages as $domain => $messages) {
+                $fileId = $this->getFileId($domain);
+
+                if (!$fileId) {
+                    continue;
+                }
+
+                $stringsMap = $this->mapStrings($fileId);
+
+                foreach ($messages as $id => $message) {
+                    if (!isset($stringsMap[$id])) {
+                        continue;
+                    }
+
+                    $this->deleteString($stringsMap[$id]);
+                }
+            }
+        }
+    }
+
+    protected function getDefaultHost(): string
+    {
+        if ($this->organizationDomain) {
+            return sprintf('%s.%s', $this->organizationDomain, self::HOST);
+        } else {
+            return self::HOST;
+        }
+    }
+
+    protected function getDefaultHeaders(): array
+    {
+        return [
+            'Authorization' => 'Bearer ' . $this->apiToken
+        ];
+    }
+
+    private function getFileId(string $domain): int
+    {
+        if (isset($this->files[$domain]) && $this->files[$domain]) {
+            return $this->files[$domain];
+        }
+
+        $files = $this->getFilesList();
+
+        foreach($files as $file) {
+            if ($file['data']['name'] === sprintf('%s.%s', $domain, 'xlf')) {
+                $this->files[$domain] = (int)$file['data']['id'];
+
+                return $this->files[$domain];
+            }
+        }
+
+        return 0;
+    }
+
+    private function mapStrings(int $fileId): array
+    {
+        $result = [];
+
+        $limit = 500;
+        $offset = 0;
+
+        do {
+            $strings = $this->listStrings($fileId, $limit, $offset);
+
+            foreach ($strings as $string) {
+                $result[$string['data']['text']] = $string['data']['id'];
+            }
+
+            $offset += $limit;
+        } while (count($strings) > 0);
+
+        return $result;
+    }
+
+    private function addFile(string $domain, string $content): void
+    {
+        $storageId = $this->addStorage($domain, $content);
+
+        /**
+         * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.getMany (Crowdin API)
+         * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.files.getMany (Crowdin Enterprise API)
+         */
+        $response = $this->client->request('POST', sprintf('https://%s/projects/%s/files', $this->getEndpoint(), $this->projectId), [
+            'headers' => array_merge($this->getDefaultHeaders(), [
+                'Content-Type' => 'application/json',
+            ]),
+            'body' => json_encode([
+                'storageId' => $storageId,
+                'name' => sprintf('%s.%s', $domain, 'xlf'),
+            ]),
+        ]);
+
+        $responseContent = $response->getContent(false);
+
+        if (Response::HTTP_CREATED !== $response->getStatusCode()) {
+            throw new ProviderException(sprintf('Unable to add a File in Crowdin for domain "%s": "%s".', $domain, $responseContent), $response);
+        }
+    }
+
+    private function updateFile(int $fileId, string $domain, string $content): void
+    {
+        $storageId = $this->addStorage($domain, $content);
+
+        /**
+         * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.put (Crowdin API)
+         * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.files.put (Crowdin Enterprise API)
+         */
+        $response = $this->client->request('PUT', sprintf('https://%s/projects/%s/files/%d', $this->getEndpoint(), $this->projectId, $fileId), [
+            'headers' => array_merge($this->getDefaultHeaders(), [
+                'Content-Type' => 'application/json',
+            ]),
+            'body' => json_encode([
+                'storageId' => $storageId,
+            ]),
+        ]);
+
+        if (Response::HTTP_OK !== $response->getStatusCode()) {
+            throw new ProviderException(
+                sprintf('Unable to update file in Crowdin for file ID "%d" and domain "%s".', $fileId, $domain),
+                $response
+            );
+        }
+    }
+
+    private function uploadTranslations(int $fileId, string $domain, string $content, string $locale): void
+    {
+        if (!$fileId) {
+            return;
+        }
+
+        $storageId = $this->addStorage($domain, $content);
+
+        /**
+         * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.postOnLanguage (Crowdin API)
+         * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.translations.postOnLanguage (Crowdin Enterprise API)
+         */
+        $response = $this->client->request('POST', sprintf('https://%s/projects/%s/translations/%s', $this->getEndpoint(), $this->projectId, $locale), [
+            'headers' => array_merge($this->getDefaultHeaders(), [
+                'Content-Type' => 'application/json',
+            ]),
+            'body' => json_encode([
+                'storageId' => $storageId,
+                'fileId' => $fileId,
+            ]),
+        ]);
+
+        if (Response::HTTP_OK !== $response->getStatusCode()) {
+            throw new ProviderException(
+                sprintf('Unable to upload translations to Crowdin for domain "%s" and locale "%s".', $domain, $locale),
+                $response
+            );
+        }
+    }
+
+    private function exportProjectTranslations(string $languageId, int $fileId): string
+    {
+        /**
+         * @see https://support.crowdin.com/api/v2/#operation/api.projects.translations.exports.post (Crowdin API)
+         * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.translations.exports.post (Crowdin Enterprise API)
+         */
+        $response = $this->client->request('POST', sprintf('https://%s/projects/%d/translations/exports', $this->getEndpoint(), $this->projectId), [
+            'headers' => array_merge($this->getDefaultHeaders(), [
+                'Content-Type' => 'application/json',
+            ]),
+            'body' => json_encode([
+                'targetLanguageId' => $languageId,
+                'fileIds' => [$fileId],
+            ]),
+        ]);
+
+        if (Response::HTTP_NO_CONTENT === $response->getStatusCode()) {
+            throw new ProviderException(
+                sprintf('No content in exported file %d.', $fileId),
+                $response
+            );
+        }
+
+        if (Response::HTTP_OK !== $response->getStatusCode()) {
+            throw new ProviderException(
+                sprintf('Unable to export file %d translations for language %s.', $fileId, $languageId),
+                $response
+            );
+        }
+
+        $export = json_decode($response->getContent(), true);
+
+        $exportResponse = $this->client->request('GET', $export['data']['url']);
+
+        if (Response::HTTP_OK !== $exportResponse->getStatusCode()) {
+            throw new ProviderException(
+                sprintf('Unable to download file %d translations content for language %s.', $fileId, $languageId),
+                $exportResponse
+            );
+        }
+
+        return $exportResponse->getContent();
+    }
+
+    private function downloadSourceFile(int $fileId): string
+    {
+        /**
+         * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.download.get (Crowdin API)
+         * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.files.download.get (Crowdin Enterprise API)
+         */
+        $response = $this->client->request('GET', sprintf('https://%s/projects/%d/files/%d/download', $this->getEndpoint(), $this->projectId, $fileId), [
+            'headers' => array_merge($this->getDefaultHeaders(), [
+                'Content-Type' => 'application/json',
+            ])
+        ]);
+
+        if (Response::HTTP_OK !== $response->getStatusCode()) {
+            throw new ProviderException(
+                sprintf('Unable to download source file %d.', $fileId),
+                $response
+            );
+        }
+
+        $export = json_decode($response->getContent(), true);
+
+        $exportResponse = $this->client->request('GET', $export['data']['url']);
+
+        if (Response::HTTP_OK !== $exportResponse->getStatusCode()) {
+            throw new ProviderException(
+                sprintf('Unable to download source file %d content.', $fileId),
+                $exportResponse
+            );
+        }
+
+        return $exportResponse->getContent();
+    }
+
+    private function listStrings(int $fileId, int $limit, int $offset): array
+    {
+        /**
+         * @see https://support.crowdin.com/api/v2/#operation/api.projects.strings.getMany (Crowdin API)
+         * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.strings.getMany (Crowdin Enterprise API)
+         */
+        $response = $this->client->request('GET', sprintf('https://%s/projects/%d/strings', $this->getEndpoint(), $this->projectId), [
+            'headers' => $this->getDefaultHeaders(),
+            'query' => [
+                'fileId' => $fileId,
+                'limit' => $limit,
+                'offset' => $offset
+            ],
+        ]);
+
+        if (Response::HTTP_OK !== $response->getStatusCode()) {
+            throw new ProviderException(
+                sprintf('Unable to list strings for file %d in project %d. Message: %s.', $fileId, $this->projectId, $response->getContent()),
+                $response
+            );
+        }
+
+        return json_decode($response->getContent(), true)['data'];
+    }
+
+    private function deleteString(int $stringId): void
+    {
+        /**
+         * @see https://support.crowdin.com/api/v2/#operation/api.projects.strings.delete (Crowdin API)
+         * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.strings.delete (Crowdin Enterprise API)
+         */
+        $response = $this->client->request('DELETE', sprintf('https://%s/projects/%d/strings/%d', $this->getEndpoint(), $this->projectId, $stringId), [
+            'headers' => $this->getDefaultHeaders()
+        ]);
+
+        if (Response::HTTP_NOT_FOUND === $response->getStatusCode()) {
+            throw new ProviderException(
+                sprintf('String ID %d Not Found for the project %d.', $stringId, $this->projectId),
+                $response
+            );
+        }
+
+        if (Response::HTTP_NO_CONTENT !== $response->getStatusCode()) {
+            throw new ProviderException(
+                sprintf('Unable to delete string %d in project %d. Message: %s.', $stringId, $this->projectId, $response->getContent()),
+                $response
+            );
+        }
+    }
+
+    private function addStorage(string $domain, string $content): int
+    {
+        /**
+         * @see https://support.crowdin.com/api/v2/#operation/api.storages.post (Crowdin API)
+         * @see https://support.crowdin.com/enterprise/api/#operation/api.storages.post (Crowdin Enterprise API)
+         */
+        $response = $this->client->request('POST', sprintf('https://%s/storages', $this->getEndpoint()), [
+            'headers' => array_merge($this->getDefaultHeaders(), [
+                'Crowdin-API-FileName' => urlencode(sprintf('%s.%s', $domain, 'xlf')),
+                'Content-Type' => 'application/octet-stream',
+            ]),
+            'body' => $content,
+        ]);
+
+        if (Response::HTTP_CREATED !== $response->getStatusCode()) {
+            throw new ProviderException(sprintf('Unable to add a Storage in Crowdin for domain "%s".', $domain), $response);
+        }
+
+        $storage = json_decode($response->getContent(), true);
+
+        return $storage['data']['id'];
+    }
+
+    private function getFilesList(): array
+    {
+        /**
+         * @see https://support.crowdin.com/api/v2/#operation/api.projects.files.getMany (Crowdin API)
+         * @see https://support.crowdin.com/enterprise/api/#operation/api.projects.files.getMany (Crowdin Enterprise API)
+         */
+        $response = $this->client->request('GET', sprintf('https://%s/projects/%d/files', $this->getEndpoint(), $this->projectId), [
+            'headers' => array_merge($this->getDefaultHeaders(), [
+                'Content-Type' => 'application/json',
+            ]),
+        ]);
+
+        if (Response::HTTP_OK !== $response->getStatusCode()) {
+            throw new ProviderException('Unable to list Crowdin files.', $response);
+        }
+
+        return json_decode($response->getContent(), true)['data'];
+    }
+}

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Provider/CrowdinProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Provider/CrowdinProviderFactory.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Bridge\Crowdin\Provider;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Translation\Dumper\XliffFileDumper;
+use Symfony\Component\Translation\Exception\UnsupportedSchemeException;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\Provider\AbstractProviderFactory;
+use Symfony\Component\Translation\Provider\Dsn;
+use Symfony\Component\Translation\Provider\ProviderInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Andrii Bodnar <andrii.bodnar@crowdin.com>
+ *
+ * @experimental in 5.3
+ */
+final class CrowdinProviderFactory extends AbstractProviderFactory
+{
+    public const SCHEME = 'crowdin';
+
+    private const DSN_OPTION_DOMAIN = 'domain';
+
+    /** @var LoaderInterface */
+    private $loader;
+
+    /** @var XliffFileDumper */
+    private $xliffFileDumper;
+
+    public function __construct(HttpClientInterface $client = null, LoggerInterface $logger = null, string $defaultLocale = null, LoaderInterface $loader = null, XliffFileDumper $xliffFileDumper = null)
+    {
+        parent::__construct($client, $logger, $defaultLocale);
+
+        $this->loader = $loader;
+        $this->xliffFileDumper = $xliffFileDumper;
+    }
+
+    /**
+     * @param Dsn $dsn
+     * @return CrowdinProvider
+     */
+    public function create(Dsn $dsn): ProviderInterface
+    {
+        if (self::SCHEME === $dsn->getScheme()) {
+            return (new CrowdinProvider($this->getUser($dsn), $this->getPassword($dsn), $dsn->getOption(self::DSN_OPTION_DOMAIN), $this->client, $this->loader, $this->logger, $this->defaultLocale, $this->xliffFileDumper))
+                ->setHost('default' === $dsn->getHost() ? null : $dsn->getHost())
+                ->setPort($dsn->getPort())
+            ;
+        }
+
+        throw new UnsupportedSchemeException($dsn, self::SCHEME, $this->getSupportedSchemes());
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return [self::SCHEME];
+    }
+}

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/README.md
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/README.md
@@ -1,0 +1,33 @@
+Crowdin Translation Provider
+=================
+
+Provides Crowdin integration for Symfony Translation.
+
+DSN example
+-----------
+
+```
+// .env file
+CROWDIN_DSN=crowdin://PROJECT_ID:API_TOKEN@default?domain=ORGANIZATION_DOMAIN
+```
+
+where:
+ - `PROJECT_ID` is your Crowdin Project ID
+ - `API_KEY` is your Crowdin API Token
+ - `ORGANIZATION_DOMAIN` is your Crowdin Enterprise Organization domain (required only for Crowdin Enterprise usage)
+
+To generate a new token in Crowdin, follow these steps:
+ - Go to Account Settings > API tab, Personal Access Tokens section, and click New Token.
+ - Specify Token Name and click Create.
+
+To generate a new token in Crowdin Enterprise, follow these steps:
+ - Go to Account Settings > Access tokens tab and click New token.
+ - Specify Token Name, select Scopes and Projects, click Create.
+
+Resources
+---------
+
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderFactoryTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderFactoryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Symfony\Component\Translation\Bridge\Crowdin\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Bridge\Crowdin\Provider\CrowdinProviderFactory;
+use Symfony\Component\Translation\Exception\IncompleteDsnException;
+use Symfony\Component\Translation\Exception\UnsupportedSchemeException;
+use Symfony\Component\Translation\Provider\Dsn;
+
+class CrowdinProviderFactoryTest extends TestCase
+{
+    public function testCreateWithDsn()
+    {
+        $factory = $this->createFactory();
+
+        $provider = $factory->create(Dsn::fromString('crowdin://PROJECT_ID:API_TOKEN@default'));
+
+        $this->assertSame('crowdin://api.crowdin.com/api/v2', (string) $provider);
+    }
+
+    public function testCreateWithOrganizationDsn()
+    {
+        $factory = $this->createFactory();
+
+        $provider = $factory->create(Dsn::fromString('crowdin://PROJECT_ID:API_TOKEN@default?domain=ORGANIZATION_DOMAIN'));
+
+        $this->assertSame('crowdin://ORGANIZATION_DOMAIN.api.crowdin.com/api/v2', (string) $provider);
+    }
+
+    public function testCreateWithNoApiKeyThrowsIncompleteDsnException()
+    {
+        $factory = $this->createFactory();
+
+        $this->expectException(IncompleteDsnException::class);
+        $factory->create(Dsn::fromString('crowdin://default'));
+    }
+
+    public function testSupportsReturnsTrueWithSupportedScheme()
+    {
+        $factory = $this->createFactory();
+
+        $this->assertTrue($factory->supports(Dsn::fromString('crowdin://PROJECT_ID:API_TOKEN@default')));
+    }
+
+    public function testSupportsReturnsTrueWithSupportedSchemeEnterprise()
+    {
+        $factory = $this->createFactory();
+
+        $this->assertTrue($factory->supports(Dsn::fromString('crowdin://PROJECT_ID:API_TOKEN@default?domain=ORGANIZATION_DOMAIN')));
+    }
+
+    public function testSupportsReturnsFalseWithUnsupportedScheme()
+    {
+        $factory = $this->createFactory();
+
+        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://PROJECT_ID:API_TOKEN@default')));
+    }
+
+    public function testSupportsReturnsFalseWithUnsupportedSchemeEnterprise()
+    {
+        $factory = $this->createFactory();
+
+        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://PROJECT_ID:API_TOKEN@default?domain=ORGANIZATION_DOMAIN')));
+    }
+
+    public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
+    {
+        $factory = $this->createFactory();
+
+        $this->expectException(UnsupportedSchemeException::class);
+        $factory->create(Dsn::fromString('somethingElse://PROJECT_ID:API_TOKEN@default'));
+    }
+
+    private function createFactory(): CrowdinProviderFactory
+    {
+        return new CrowdinProviderFactory();
+    }
+}

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Symfony\Component\Translation\Bridge\Crowdin\Tests;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
+use Symfony\Component\Translation\Bridge\Crowdin\Provider\CrowdinProvider;
+
+class CrowdinProviderTest extends TestCase
+{
+    public function toStringDataProvider(): Generator
+    {
+        yield [
+            new CrowdinProvider('PROJECT_ID', 'API_TOKEN'),
+            'crowdin://api.crowdin.com/api/v2',
+        ];
+
+        yield [
+            (new CrowdinProvider('PROJECT_ID', 'API_TOKEN'))->setHost('crowdin.com'),
+            'crowdin://crowdin.com',
+        ];
+
+        yield [
+            (new CrowdinProvider('PROJECT_ID', 'API_TOKEN'))->setHost('example.com')->setPort(19),
+            'crowdin://example.com:19',
+        ];
+
+        yield [
+            (new CrowdinProvider('PROJECT_ID', 'API_TOKEN', 'organization')),
+            'crowdin://organization.api.crowdin.com/api/v2',
+        ];
+    }
+
+    /**
+     * @dataProvider toStringDataProvider
+     * @param CrowdinProvider $provider
+     * @param string $expected
+     */
+    public function testToString(CrowdinProvider $provider, string $expected): void
+    {
+        $this->assertSame($expected, (string) $provider);
+    }
+
+    public function testGetName(): void
+    {
+        $this->assertSame('crowdin', (new CrowdinProvider('PROJECT_ID', 'API_TOKEN'))->getName());
+    }
+
+    public function getDefaultHostDataProvider(): Generator
+    {
+        yield [
+            new CrowdinProvider('PROJECT_ID', 'API_TOKEN', 'ORGANIZATION_DOMAIN'),
+            'ORGANIZATION_DOMAIN.api.crowdin.com/api/v2',
+        ];
+
+        yield [
+            new CrowdinProvider('PROJECT_ID', 'API_TOKEN'),
+            'api.crowdin.com/api/v2',
+        ];
+    }
+
+    /**
+     * @dataProvider getDefaultHostDataProvider
+     * @param CrowdinProvider $provider
+     * @param string $expected
+     * @throws ReflectionException
+     */
+    public function testGetDefaultHost(CrowdinProvider $provider, string $expected): void
+    {
+        $reflection = new ReflectionClass(get_class($provider));
+        $method = $reflection->getMethod('getDefaultHost');
+        $method->setAccessible(true);
+
+        $actualResult = $method->invokeArgs($provider, []);
+
+        $this->assertSame($expected, $actualResult);
+    }
+
+    public function testGetDefaultHeaders(): void
+    {
+        $provider = new CrowdinProvider('PROJECT_ID', 'API_TOKEN');
+
+        $reflection = new ReflectionClass(get_class($provider));
+        $method = $reflection->getMethod('getDefaultHeaders');
+        $method->setAccessible(true);
+
+        $actualResult = $method->invokeArgs($provider, []);
+
+        $this->assertSame(['Authorization' => 'Bearer API_TOKEN'], $actualResult);
+    }
+}

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "symfony/crowdin-translation-bridge",
+    "type": "symfony-bridge",
+    "description": "Symfony Crowdin Translation Bridge",
+    "keywords": ["Crowdin", "translation", "provider"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Mathieu Santostefano",
+            "homepage": "https://github.com/welcomattic"
+        },
+        {
+            "name": "Andrii Bodnar",
+            "homepage": "https://github.com/andrii-bodnar"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=7.2.5",
+        "symfony/http-client": "^5.2",
+        "symfony/translation": "^5.2"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Translation\\Bridge\\Crowdin\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/phpunit.xml.dist
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Crowdin Translation Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
Hi!

It's a cool idea to make Translation Providers for Symfony. Great job, guys! :+1: 

Previously I helped @welcoMattic with some Crowdin API methods in the [first PR](https://github.com/symfony/symfony/pull/37462) and in chat in the Symfony Devs Slack workspace.

A few weeks ago a checked the [new PR](https://github.com/symfony/symfony/pull/38475) and realized that Crowdin Provider is missing.

So, I decided to do it by myself (of course, after @welcoMattic's approval) :slightly_smiling_face:

Therefore, this PR adds Crowdin Provider to the Translation Providers feature. It already supports both [crowdin.com](https://crowdin.com/) and [Crowdin Enterprise](https://crowdin.com/enterprise).